### PR TITLE
feat: unix-print打印pdf文件支持外部传入lp命令

### DIFF
--- a/src/pdf-print.js
+++ b/src/pdf-print.js
@@ -3,8 +3,8 @@
  * @Author: CcSimple
  * @Github: https://github.com/CcSimple
  * @Date: 2023-04-21 16:35:07
- * @LastEditors: CcSimple
- * @LastEditTime: 2023-07-14 14:09:19
+ * @LastEditors: JZT.吴健
+ * @LastEditTime: 2025-09-26 14:10:48
  */
 const pdfPrint1 = require("pdf-to-printer");
 const pdfPrint2 = require("unix-print");
@@ -46,9 +46,8 @@ const realPrint = (pdfPath, printer, data, resolve, reject) => {
         reject();
       });
   } else {
-    // 参数见 lp 命令 使用方法
-    let options = [];
-    printPdfFunction(pdfPath, printer, options)
+    // 参数见 lp 命令 使用方法, 使用外部传入的lp命令
+    printPdfFunction(pdfPath, printer, data.unixPrintOptions || [])
       .then(() => {
         resolve();
       })


### PR DESCRIPTION
类unix系统下打印pdf，当pdf尺寸（比A4的宽度210mm多0.几mm时），打印机一直报纸张尺寸不匹配，无法静默打，通过外部传入["-o sides=one-sided", "-o fit-to-page", "-o media=A4"];等命令，打印成功，也可控制单面打，适配纸张等其他特性